### PR TITLE
Add inverse class to rladies.scss 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ Files created:
 - [Quarto documentation](https://quarto.org/docs/extensions/formats.html)
 
 - [Martine Jansen](https://twitter.com/nnie_nl) - Martine's questions helped to improve the template content in order to make it easier for other people to use it!
+
+- [Martine Jansen](https://github.com/MMJansen) - Suggested the addition of the `.inverse` class.

--- a/_extensions/rladies/_extension.yml
+++ b/_extensions/rladies/_extension.yml
@@ -1,6 +1,6 @@
 title: R-Ladies Presentation Template
 author: Beatriz Milz
-version: 0.0.3
+version: 0.0.4
 contributes:
   formats: 
     revealjs:

--- a/_extensions/rladies/rladies.scss
+++ b/_extensions/rladies/rladies.scss
@@ -86,3 +86,10 @@ section.has-dark-background a, section.has-dark-background a:hover {
   top: unset !important;
   color: $body-color !important;
 }
+
+.inverse {
+  background-color: #562457 !important;
+  $h1-color: white !important;
+  $h2-color: white !important;
+  $h3-color: white !important;
+}


### PR DESCRIPTION
Fixes #6

Add `.inverse` class to `rladies.scss` file

* Add `.inverse` class with specified styles to `_extensions/rladies/rladies.scss` file
* Acknowledge the suggestion from GitHub user @MMJansen in `README.md`
* Increase minor version in `_extensions/rladies/_extension.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/beatrizmilz/quarto-rladies-theme/pull/7?shareId=b8173a3d-bf16-4e14-90e9-bc3e11b2cc0e).